### PR TITLE
handle SIGTERM by stopping all running services

### DIFF
--- a/main.go
+++ b/main.go
@@ -403,7 +403,7 @@ func stopService(serviceName string) {
 			processCheckCounter++
 		}
 
-		if processExitedCleanly {
+		if !processExitedCleanly {
 			log.Printf("[%s] Timed out waiting, sending SIGKILL to service process: %d", serviceName, runningService.cmd.Process.Pid)
 			err := runningService.cmd.Process.Kill()
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ var (
 func main() {
 	exit := make(chan os.Signal, 1)
 	signal.Notify(exit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(exit, os.Interrupt, syscall.SIGINT)
 
 	configFilePath := flag.String("c", "config.json", "path to config.json")
 	flag.Parse()


### PR DESCRIPTION
currently, the behavior on SIGTERM is to exit ourselves but still leave all child processes running. this patch changes the behavior to actively catch SIGTERM and so, gracefully shutdown the services (by sending SIGTERM to them, waiting 2 seconds, then SIGKILL).

the TODO comment regarding wait-until-SIGKILL is left as more of a suggestion, if that's welcome I can submit that in a separate PR.