### PR TITLE
add idle timeout fallback for old configs

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func getIdleTimeout(serviceConfig ServiceConfig) time.Duration {
 	}
 	// for old configs
 	if idleTimeout == 0 {
-		idleTimeout = 5 * 60
+		idleTimeout = 2 * 60
 	}
 	idleTimeout = idleTimeout * time.Second
 	return idleTimeout

--- a/main.go
+++ b/main.go
@@ -200,6 +200,10 @@ func getIdleTimeout(serviceConfig ServiceConfig) time.Duration {
 	if idleTimeout == 0 {
 		idleTimeout = config.ShutDownAfterInactivitySeconds
 	}
+	// for old configs
+	if idleTimeout == 0 {
+		idleTimeout = 5 * 60
+	}
 	idleTimeout = idleTimeout * time.Second
 	return idleTimeout
 }


### PR DESCRIPTION
leaving it at 0 leads to a hard panic, and it will be at 0 for configs that don't have the field (like mine, lol)

```
2024/08/04 19:34:06 [...] Idle timeout 0s reached, but service is busy, resetting idle time
2024/08/04 19:34:06 [...] Idle timeout 0s reached, but service is busy, resetting idle time
2024/08/04 19:34:06 [...] Idle timeout 0s reached, but service is busy, resetting idle time
2024/08/04 19:34:06 [...] Idle timeout 0s reached, but service is busy, resetting idle time
2024/08/04 19:34:06 [...] Done stopping pid 33393
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x51e180]

goroutine 3162 [running]:
sync.(*Mutex).TryLock(...)
        /usr/lib/golang/src/sync/mutex.go:99
main.canBeStopped({0xc000014600, 0xb})
        /home/luna/other.git/large-model-proxy/main.go:376 +0x60
main.startService.func1()
        /home/luna/other.git/large-model-proxy/main.go:236 +0x4a
created by time.goFunc
        /usr/lib/golang/src/time/sleep.go:177 +0x2d
exit status 2
```