### PR TITLE
use shlex for args split

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,9 @@ jobs:
       with:
         go-version: '1.20'
 
+    - name: Download dependencies
+      run: go mod download
+
     - name: Build
       run: go build -v
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module large-model-proxy
 
 go 1.18
+
+require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=

--- a/main.go
+++ b/main.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/google/shlex"
 )
 
 type RunningService struct {
@@ -777,7 +779,14 @@ func runServiceCommand(serviceConfig ServiceConfig) *exec.Cmd {
 		serviceConfig.LogFilePath,
 		serviceConfig.Workdir,
 	)
-	cmd := exec.Command(serviceConfig.Command, strings.Split(serviceConfig.Args, " ")...)
+
+	args, err := shlex.Split(serviceConfig.Args)
+	if err != nil {
+		log.Printf("[%s] Failed to parse service arguments %s: %v", serviceConfig.Name, serviceConfig.Args, err)
+		return nil
+	}
+
+	cmd := exec.Command(serviceConfig.Command, args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 		Pgid:    0,

--- a/test-server/args-with-whitespace.json
+++ b/test-server/args-with-whitespace.json
@@ -1,0 +1,12 @@
+{
+  "Services": [
+    {
+      "Name": "test-args-and-env",
+      "ListenPort": "2025",
+      "ProxyTargetHost": "localhost",
+      "ProxyTargetPort": "12027",
+      "Command": "test-server/test-server",
+      "Args": "   -procinfo-port 12027"
+    }
+  ]
+}

--- a/test-server/with-env.json
+++ b/test-server/with-env.json
@@ -1,0 +1,12 @@
+{
+  "Services": [
+    {
+      "Name": "test-args-and-env",
+      "ListenPort": "2026",
+      "ProxyTargetHost": "localhost",
+      "ProxyTargetPort": "12028",
+      "Command": "env",
+      "Args": "COOL_VARIABLE=1    ./test-server/test-server     -procinfo-port 12028"
+    }
+  ]
+}


### PR DESCRIPTION
if you want to add environment variables to the service, at the moment you need to set Command to `"env"`, but if you typo it such that Args is `" /script.sh"` (say, bad logic in a template script, which is what happened to me) you'll call env with args `["", "/script.sh"]`, and so `env` will fail like this:

```
env: ‘’: No such file or directory
```

using `shlex.Split` lets us give more consistent behavior to a real shell, but I'd be fine with letting ServiceConfig set cmd.Env instead of adding the first external dependency to the project :P