### PR TITLE
Fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To the client this should be fully transparent with the only exception being tha
     ```
 4. Build the project:
     ```sh
-    go build -o large-model-proxy main.go
+    go build -o large-model-proxy
     ```
     or
    ```sh


### PR DESCRIPTION
Including `main.go` breaks the build as it won't include the other files required for the build. This updates the README to remove that and make it consistent with the Makefile.