### PR TITLE
feat: add management API + status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,21 @@ It will probably not work on Windows natively as it is using Unix Process Groups
 ## Configuration
 
 Below is an example config.json:
+
 ```json
 {
-   "OpenAiApi": {
-      "ListenPort": "7070"
-   }, 
+  "OpenAiApi": {
+    "ListenPort": "7070"
+  },
+  "ManagementApi": {
+    "ListenPort": "7071"
+  },
   "MaxTimeToWaitForServiceToCloseConnectionBeforeGivingUpSeconds": 1200,
   "ShutDownAfterInactivitySeconds": 120,
   "ResourcesAvailable": {
-     "VRAM-GPU-1": 24000,
-     "RAM": 32000
-  }, 
+    "VRAM-GPU-1": 24000,
+    "RAM": 32000
+  },
   "Services": [
     {
       "Name": "automatic1111",
@@ -68,7 +72,7 @@ Below is an example config.json:
       "ProxyTargetPort": "17860",
       "Command": "/opt/stable-diffusion-webui/webui.sh",
       "Args": "--port 17860",
-      "WorkDir": "/opt/stable-diffusion-webui", 
+      "WorkDir": "/opt/stable-diffusion-webui",
       "ShutDownAfterInactivitySeconds": 600,
       "RestartOnConnectionFailure": true,
       "ResourceRequirements": {
@@ -84,7 +88,7 @@ Below is an example config.json:
       "ProxyTargetPort": "18081",
       "Command": "/opt/llama.cpp/llama-server",
       "Args": "-m /opt/Gemma-27B-v1_Q4km.gguf -c 8192 -ngl 100 -t 4 --port 18081",
-      "HealthcheckCommand": "curl --fail http://localhost:18081/health", 
+      "HealthcheckCommand": "curl --fail http://localhost:18081/health",
       "HealthcheckIntervalMilliseconds": 200,
       "RestartOnConnectionFailure": false,
       "ResourceRequirements": {

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Bellow is a breakdown of what this configuration does:
    * Automatic1111's Stable Diffusion web UI on port 7860
    * llama.cpp with Gemma2 on port 8081
    * OpenAI API on port 7070, supporting Gemma2 via llama.cpp and Qwen2.5-7B-Instruct via vLLM, depending on the `model` specified in the JSON payload.
+   * Management server on port 7071 (optional). If `ManagementServer.ListenPort` is not specified in the config, the management server will not run.
    * ComfyUI on port 8188 through a Docker container, which exposes the internal port 8188 as 18188 on the host, which is then proxied back to 8188 when active.
 2. Internally large-model-proxy will expect Automatic1111 to be available on port 17860, Gemma27B on port 18081, Qwen2.5-7B-Instruct on port 18082, and ComfyUI on port 18188 once it runs the commands given in "Command" parameter and healthcheck passes. 
 3. This config allocates up to 24GB of VRAM and 32GB of RAM for them. No more GPU or RAM will be attempted to be used (assuming the values in ResourceRequirements are correct).
@@ -153,6 +154,17 @@ Currently, the following OpenAI API endpoints are supported:
 * `/v1/chat/completions`
 * `/v1/models` (This one makes it work with e.g. Open WebUI seamlessly).
 * More to come
+
+## Management API
+
+The management API is a simple HTTP API that allows you to get the status of the proxy and the services it is proxying.
+
+To enable it, you need to specify `ManagementApi.ListenPort` in the config.
+
+Currently, the only endpoint is `/status`, which returns a JSON object with the following fields:
+* `all_services`: A list of all services managed by the proxy.
+* `running_services`: A list of all services that are currently running.
+* `resources`: A map of all resources managed by the proxy and their usage.
 
 ## Logs
 

--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Services                                                      []ServiceConfig `json:"Services"`
 	ResourcesAvailable                                            map[string]int  `json:"ResourcesAvailable"`
 	OpenAiApi                                                     OpenAiApi
+	ManagementApi                                                 ManagementApi
 }
 
 type ServiceConfig struct {
@@ -36,7 +37,11 @@ type ServiceConfig struct {
 	OpenAiApiModels                 []string
 	ResourceRequirements            map[string]int `json:"ResourceRequirements"`
 }
+
 type OpenAiApi struct {
+	ListenPort string
+}
+type ManagementApi struct {
 	ListenPort string
 }
 
@@ -164,6 +169,14 @@ func validateConfig(cfg Config) error {
 		if err != nil || portVal <= 0 || portVal > 65535 {
 			issues = append(issues,
 				fmt.Sprintf("top-level OpenAiApi.ListenPort is invalid: %q", cfg.OpenAiApi.ListenPort))
+		}
+	}
+
+	if cfg.ManagementApi.ListenPort != "" {
+		portVal, err := strconv.Atoi(cfg.ManagementApi.ListenPort)
+		if err != nil || portVal <= 0 || portVal > 65535 {
+			issues = append(issues,
+				fmt.Sprintf("top-level ManagementApi.ListenPort is invalid: %q", cfg.ManagementApi.ListenPort))
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -224,6 +224,9 @@ func TestValidateConfig(t *testing.T) {
 				OpenAiApi: OpenAiApi{
 					ListenPort: "6060",
 				},
+				ManagementApi: ManagementApi{
+					ListenPort: "7071",
+				},
 				Services: []ServiceConfig{
 					{
 						Name:       "svcOk",
@@ -245,6 +248,24 @@ func TestValidateConfig(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "Invalid ManagementApi port",
+			cfg: Config{
+				ResourcesAvailable: map[string]int{"RAM": 10000},
+				ManagementApi: ManagementApi{
+					ListenPort: "99999",
+				},
+				Services: []ServiceConfig{
+					{
+						Name:       "svcOk",
+						ListenPort: "9000",
+						Command:    "/bin/echo",
+					},
+				},
+			},
+			wantErr:        true,
+			expectedErrMsg: []string{"top-level ManagementApi.ListenPort is invalid: \"99999\""},
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -141,6 +141,9 @@ func main() {
 	if config.OpenAiApi.ListenPort != "" {
 		go startOpenAiApi(config.OpenAiApi, config.Services)
 	}
+	if config.ManagementApi.ListenPort != "" {
+		go startManagementApi(config.ManagementApi, config.Services)
+	}
 	for {
 		receivedSignal := <-exit
 		log.Printf("Received %s signal, terminating all processes", signalToString(receivedSignal))

--- a/management_api.go
+++ b/management_api.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+// handleStatus handles the /status endpoint request
+func handleStatus(responseWriter http.ResponseWriter, request *http.Request, services []ServiceConfig) {
+	// ServiceStatus represents the current state of a service
+	type ServiceStatus struct {
+		Name               string         `json:"name"`
+		ListenPort         string         `json:"listen_port"`
+		IsRunning          bool           `json:"is_running"`
+		ActiveConnections  int            `json:"active_connections"`
+		LastUsed           time.Time      `json:"last_used"`
+		ResourceAllocation map[string]int `json:"resource_allocation"`
+	}
+
+	// ResourceUsage represents the current usage of a resource
+	type ResourceUsage struct {
+		TotalAvailable int            `json:"total_available"`
+		TotalInUse     int            `json:"total_in_use"`
+		UsageByService map[string]int `json:"usage_by_service"`
+	}
+
+	// StatusResponse represents the complete status response
+	type StatusResponse struct {
+		AllServices     []ServiceStatus          `json:"all_services"`
+		RunningServices []ServiceStatus          `json:"running_services"`
+		Resources       map[string]ResourceUsage `json:"resources"`
+	}
+
+	responseWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	// Lock to safely access resource manager state
+	resourceManager.serviceMutex.Lock()
+	defer resourceManager.serviceMutex.Unlock()
+
+	response := StatusResponse{
+		AllServices:     make([]ServiceStatus, 0, len(services)),
+		RunningServices: make([]ServiceStatus, 0),
+		Resources:       make(map[string]ResourceUsage),
+	}
+
+	// Initialize resource usage tracking
+	for resource := range config.ResourcesAvailable {
+		response.Resources[resource] = ResourceUsage{
+			TotalAvailable: config.ResourcesAvailable[resource],
+			TotalInUse:     resourceManager.resourcesInUse[resource],
+			UsageByService: make(map[string]int),
+		}
+	}
+
+	// Process all services
+	for _, service := range services {
+		status := ServiceStatus{
+			Name:               service.Name,
+			ListenPort:         service.ListenPort,
+			ResourceAllocation: service.ResourceRequirements,
+		}
+
+		// Check if service is running
+		if runningService, ok := resourceManager.runningServices[service.Name]; ok {
+			status.IsRunning = true
+			status.ActiveConnections = runningService.activeConnections
+			status.LastUsed = runningService.lastUsed
+
+			// Add to running services list
+			response.RunningServices = append(response.RunningServices, status)
+
+			// Update resource usage by service
+			for resource, amount := range runningService.resourceRequirements {
+				if usage, ok := response.Resources[resource]; ok {
+					usage.UsageByService[service.Name] = amount
+					response.Resources[resource] = usage
+				}
+			}
+		}
+
+		response.AllServices = append(response.AllServices, status)
+	}
+
+	// Encode and send response
+	if err := json.NewEncoder(responseWriter).Encode(response); err != nil {
+		http.Error(responseWriter, "{error: \"Failed to produce JSON response\"}", http.StatusInternalServerError)
+		log.Printf("Failed to produce /status JSON response: %s\n", err.Error())
+	}
+}
+
+// startManagementApi starts the management API on the specified port
+func startManagementApi(managementAPI ManagementApi, services []ServiceConfig) {
+	mux := http.NewServeMux()
+
+	// Add status endpoint
+	mux.HandleFunc("/status", func(responseWriter http.ResponseWriter, request *http.Request) {
+		handleStatus(responseWriter, request, services)
+	})
+
+	server := &http.Server{
+		Addr:    ":" + managementAPI.ListenPort,
+		Handler: mux,
+	}
+
+	log.Printf("[Management API] Listening on port %s", managementAPI.ListenPort)
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatalf("Could not start management API: %s\n", err.Error())
+	}
+}

--- a/management_api.go
+++ b/management_api.go
@@ -11,12 +11,12 @@ import (
 func handleStatus(responseWriter http.ResponseWriter, request *http.Request, services []ServiceConfig) {
 	// ServiceStatus represents the current state of a service
 	type ServiceStatus struct {
-		Name               string         `json:"name"`
-		ListenPort         string         `json:"listen_port"`
-		IsRunning          bool           `json:"is_running"`
-		ActiveConnections  int            `json:"active_connections"`
-		LastUsed           time.Time      `json:"last_used"`
-		ResourceAllocation map[string]int `json:"resource_allocation"`
+		Name                 string         `json:"name"`
+		ListenPort           string         `json:"listen_port"`
+		IsRunning            bool           `json:"is_running"`
+		ActiveConnections    int            `json:"active_connections"`
+		LastUsed             *time.Time     `json:"last_used"`
+		ResourceRequirements map[string]int `json:"resource_requirements"`
 	}
 
 	// ResourceUsage represents the current usage of a resource
@@ -31,6 +31,11 @@ func handleStatus(responseWriter http.ResponseWriter, request *http.Request, ser
 		AllServices     []ServiceStatus          `json:"all_services"`
 		RunningServices []ServiceStatus          `json:"running_services"`
 		Resources       map[string]ResourceUsage `json:"resources"`
+	}
+
+	if request.Method != "GET" {
+		http.Error(responseWriter, "Only GET requests allowed", http.StatusMethodNotAllowed)
+		return
 	}
 
 	responseWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -57,9 +62,9 @@ func handleStatus(responseWriter http.ResponseWriter, request *http.Request, ser
 	// Process all services
 	for _, service := range services {
 		status := ServiceStatus{
-			Name:               service.Name,
-			ListenPort:         service.ListenPort,
-			ResourceAllocation: service.ResourceRequirements,
+			Name:                 service.Name,
+			ListenPort:           service.ListenPort,
+			ResourceRequirements: service.ResourceRequirements,
 		}
 
 		// Check if service is running

--- a/management_api_test.go
+++ b/management_api_test.go
@@ -1,0 +1,287 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// StatusResponse represents the complete status response from the management API
+type StatusResponse struct {
+	AllServices     []ServiceStatus          `json:"all_services"`
+	RunningServices []ServiceStatus          `json:"running_services"`
+	Resources       map[string]ResourceUsage `json:"resources"`
+}
+
+// ServiceStatus represents the current state of a service
+type ServiceStatus struct {
+	Name                 string         `json:"name"`
+	ListenPort           string         `json:"listen_port"`
+	IsRunning            bool           `json:"is_running"`
+	ActiveConnections    int            `json:"active_connections"`
+	LastUsed             *time.Time     `json:"last_used"`
+	ResourceRequirements map[string]int `json:"resource_requirements"`
+}
+
+// ResourceUsage represents the current usage of a resource
+type ResourceUsage struct {
+	TotalAvailable int            `json:"total_available"`
+	TotalInUse     int            `json:"total_in_use"`
+	UsageByService map[string]int `json:"usage_by_service"`
+}
+
+func getStatusFromManagementAPI(t *testing.T) StatusResponse {
+	resp, err := http.Get("http://localhost:2040/status")
+	if err != nil {
+		t.Fatalf("Failed to get status from management API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status code 200, got %d", resp.StatusCode)
+	}
+
+	var statusResp StatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&statusResp); err != nil {
+		t.Fatalf("Failed to decode status response: %v", err)
+	}
+
+	return statusResp
+}
+
+// verifyServiceStatus checks if a specific service has the expected running status and resource usage
+func verifyServiceStatus(t *testing.T, resp StatusResponse, serviceName string, expectedRunning bool, expectedResources map[string]int) {
+	// Find service in allServices
+	var found bool
+	var service ServiceStatus
+
+	for _, s := range resp.AllServices {
+		if s.Name == serviceName {
+			service = s
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("Service %s not found in AllServices", serviceName)
+	}
+
+	// Check running status
+	if service.IsRunning != expectedRunning {
+		t.Errorf("Service %s - expected running: %v, actual: %v", serviceName, expectedRunning, service.IsRunning)
+	}
+
+	// Check if service is in running services if it should be running
+	foundInRunning := false
+	for _, s := range resp.RunningServices {
+		if s.Name == serviceName {
+			foundInRunning = true
+			break
+		}
+	}
+
+	if expectedRunning && !foundInRunning {
+		t.Errorf("Service %s expected to be in RunningServices but not found", serviceName)
+	} else if !expectedRunning && foundInRunning {
+		t.Errorf("Service %s not expected to be in RunningServices but was found", serviceName)
+	}
+
+	// Check resource usage
+	if expectedRunning {
+		for resource, expectedAmount := range expectedResources {
+			resourceInfo, ok := resp.Resources[resource]
+			if !ok {
+				t.Errorf("Resource %s not found in status response", resource)
+				continue
+			}
+
+			actualAmount, ok := resourceInfo.UsageByService[serviceName]
+			if !ok {
+				t.Errorf("Service %s not found in UsageByService for resource %s", serviceName, resource)
+				continue
+			}
+
+			if actualAmount != expectedAmount {
+				t.Errorf("Service %s - expected %s usage: %d, actual: %d",
+					serviceName, resource, expectedAmount, actualAmount)
+			}
+		}
+	}
+}
+
+// verifyTotalResourceUsage checks if the total resource usage matches the expected values
+func verifyTotalResourceUsage(t *testing.T, resp StatusResponse, expectedUsage map[string]int) {
+	for resource, expectedAmount := range expectedUsage {
+		resourceInfo, ok := resp.Resources[resource]
+		if !ok {
+			t.Errorf("Resource %s not found in status response", resource)
+			continue
+		}
+
+		if resourceInfo.TotalInUse != expectedAmount {
+			t.Errorf("Expected total %s usage: %d, actual: %d",
+				resource, expectedAmount, resourceInfo.TotalInUse)
+		}
+	}
+}
+
+func TestManagementAPIStatusAcrossServices(t *testing.T) {
+	// Setup test environment
+	waitChannel := make(chan error, 1)
+
+	// Start large-model-proxy with our test configuration
+	cmd, err := startLargeModelProxy("management-api-test", "test-server/management-api-test.json", waitChannel)
+	if err != nil {
+		t.Fatalf("Could not start application: %v", err)
+	}
+
+	defer func() {
+		if err := stopApplication(cmd, waitChannel); err != nil {
+			t.Errorf("Failed to stop application: %v", err)
+		}
+
+		// Verify all ports are closed after stopping
+		addresses := []string{
+			"localhost:2040", "localhost:2041", "localhost:2042", "localhost:2043",
+			"localhost:12041", "localhost:12042", "localhost:12043",
+		}
+		for _, address := range addresses {
+			if err := checkPortClosed(address); err != nil {
+				t.Errorf("Port %s is still open after application exit", address)
+			}
+		}
+	}()
+
+	// Give the management API time to start
+	time.Sleep(2 * time.Second)
+
+	// Initial check - no services should be running
+	t.Log("Checking initial status - no services should be running")
+	resp := getStatusFromManagementAPI(t)
+
+	if len(resp.RunningServices) != 0 {
+		t.Errorf("Expected 0 running services, got %d", len(resp.RunningServices))
+	}
+
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 0,
+		"GPU": 0,
+	})
+
+	// Activate Service 1 (CPU)
+	t.Log("Activating Service 1 (CPU)")
+	pid1 := runReadPidCloseConnection(t, "localhost:2041")
+	if pid1 == 0 {
+		t.Fatal("Failed to start service1-cpu")
+	}
+
+	// Wait for status to update
+	time.Sleep(1 * time.Second)
+
+	// Check status after starting Service 1
+	resp = getStatusFromManagementAPI(t)
+	verifyServiceStatus(t, resp, "service1-cpu", true, map[string]int{"CPU": 2})
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 2,
+		"GPU": 0,
+	})
+
+	// Activate Service 2 (GPU)
+	t.Log("Activating Service 2 (GPU)")
+	pid2 := runReadPidCloseConnection(t, "localhost:2042")
+	if pid2 == 0 {
+		t.Fatal("Failed to start service2-gpu")
+	}
+
+	// Wait for status to update
+	time.Sleep(1 * time.Second)
+
+	// Check status after starting Service 2
+	resp = getStatusFromManagementAPI(t)
+	verifyServiceStatus(t, resp, "service1-cpu", true, map[string]int{"CPU": 2})
+	verifyServiceStatus(t, resp, "service2-gpu", true, map[string]int{"GPU": 1})
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 2,
+		"GPU": 1,
+	})
+
+	// Activate Service 3 (CPU+GPU)
+	t.Log("Activating Service 3 (CPU+GPU)")
+	pid3 := runReadPidCloseConnection(t, "localhost:2043")
+	if pid3 == 0 {
+		t.Fatal("Failed to start service3-cpu-gpu")
+	}
+
+	// Wait for status to update
+	time.Sleep(1 * time.Second)
+
+	// Check status after starting Service 3
+	resp = getStatusFromManagementAPI(t)
+	verifyServiceStatus(t, resp, "service1-cpu", true, map[string]int{"CPU": 2})
+	verifyServiceStatus(t, resp, "service2-gpu", true, map[string]int{"GPU": 1})
+	verifyServiceStatus(t, resp, "service3-cpu-gpu", true, map[string]int{"CPU": 2, "GPU": 1})
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 4,
+		"GPU": 2,
+	})
+
+	// Wait for Service 1 to terminate due to inactivity timeout
+	t.Log("Waiting for Service 1 to terminate due to timeout")
+	time.Sleep(1 * time.Second)
+
+	resp = getStatusFromManagementAPI(t)
+	verifyServiceStatus(t, resp, "service1-cpu", false, nil)
+	verifyServiceStatus(t, resp, "service2-gpu", true, map[string]int{"GPU": 1})
+	verifyServiceStatus(t, resp, "service3-cpu-gpu", true, map[string]int{"CPU": 2, "GPU": 1})
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 2,
+		"GPU": 2,
+	})
+
+	// Wait for Service 2 to terminate due to inactivity timeout
+	t.Log("Waiting for Service 2 to terminate due to timeout")
+	time.Sleep(1 * time.Second)
+
+	resp = getStatusFromManagementAPI(t)
+	verifyServiceStatus(t, resp, "service1-cpu", false, nil)
+	verifyServiceStatus(t, resp, "service2-gpu", false, nil)
+	verifyServiceStatus(t, resp, "service3-cpu-gpu", true, map[string]int{"CPU": 2, "GPU": 1})
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 2,
+		"GPU": 1,
+	})
+
+	// Wait for Service 3 to terminate due to inactivity timeout
+	t.Log("Waiting for Service 3 to terminate due to timeout")
+	time.Sleep(1 * time.Second)
+
+	resp = getStatusFromManagementAPI(t)
+	verifyServiceStatus(t, resp, "service1-cpu", false, nil)
+	verifyServiceStatus(t, resp, "service2-gpu", false, nil)
+	verifyServiceStatus(t, resp, "service3-cpu-gpu", false, nil)
+	verifyTotalResourceUsage(t, resp, map[string]int{
+		"CPU": 0,
+		"GPU": 0,
+	})
+
+	// Verify all services are down
+	if len(resp.RunningServices) != 0 {
+		t.Errorf("Expected 0 running services at the end, got %d", len(resp.RunningServices))
+		for _, svc := range resp.RunningServices {
+			t.Logf("Still running: %s", svc.Name)
+		}
+	}
+
+	// Confirm processes are actually terminated
+	if isProcessRunning(pid1) {
+		t.Errorf("Service 1 (pid %d) is still running but should be terminated", pid1)
+	}
+	if isProcessRunning(pid2) {
+		t.Errorf("Service 2 (pid %d) is still running but should be terminated", pid2)
+	}
+	if isProcessRunning(pid3) {
+		t.Errorf("Service 3 (pid %d) is still running but should be terminated", pid3)
+	}
+}

--- a/test-server/management-api-test.json
+++ b/test-server/management-api-test.json
@@ -1,0 +1,46 @@
+{
+  "ShutDownAfterInactivitySeconds": 4,
+  "ResourcesAvailable": {
+    "CPU": 4,
+    "GPU": 2
+  },
+  "ManagementApi": {
+    "ListenPort": "2040"
+  },
+  "Services": [
+    {
+      "Name": "service1-cpu",
+      "ListenPort": "2041",
+      "ProxyTargetHost": "localhost",
+      "ProxyTargetPort": "12041",
+      "Command": "test-server/test-server",
+      "Args": "-p 12041",
+      "ResourceRequirements": {
+        "CPU": 2
+      }
+    },
+    {
+      "Name": "service2-gpu",
+      "ListenPort": "2042",
+      "ProxyTargetHost": "localhost",
+      "ProxyTargetPort": "12042",
+      "Command": "test-server/test-server",
+      "Args": "-p 12042",
+      "ResourceRequirements": {
+        "GPU": 1
+      }
+    },
+    {
+      "Name": "service3-cpu-gpu",
+      "ListenPort": "2043",
+      "ProxyTargetHost": "localhost",
+      "ProxyTargetPort": "12043",
+      "Command": "test-server/test-server",
+      "Args": "-p 12043",
+      "ResourceRequirements": {
+        "CPU": 2,
+        "GPU": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This adds a separate management API (optional) with a JSON `/status` endpoint. In future, I can see this being used for more explicit service management (i.e. explicitly starting or killing services, etc), but this seemed like a good place to start as it's immediately useful to me (my config is procedurally generated, so I don't have an easy way of knowing what ports the services are on).

I initially used the OpenAI API, but separated it out so that users can apply their own access control to the port (e.g. they might expose the OpenAI port to the outside world, but keep the management API internal).