### PR TITLE
Optional custom kill commands

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type ServiceConfig struct {
 	ProxyTargetPort                 string
 	Command                         string
 	Args                            string
+	KillCommand                     *string
 	LogFilePath                     string
 	Workdir                         string
 	HealthcheckCommand              string

--- a/config_test.go
+++ b/config_test.go
@@ -200,6 +200,21 @@ func TestValidateConfig(t *testing.T) {
 			expectedErrMsg: []string{"has negative ShutDownAfterInactivitySeconds", "serviceNegDuration"},
 		},
 		{
+			name: "Standard KillCommand works",
+			cfg: Config{
+				ResourcesAvailable: map[string]int{"RAM": 10000},
+				Services: []ServiceConfig{
+					{
+						Name:        "killCommandWorks",
+						ListenPort:  "8090",
+						Command:     "/bin/echo",
+						KillCommand: stringPtr("/bin/echo"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "All checks pass (bigger example)",
 			cfg: Config{
 				ResourcesAvailable: map[string]int{
@@ -219,9 +234,10 @@ func TestValidateConfig(t *testing.T) {
 						},
 					},
 					{
-						Name:       "svcOk2",
-						ListenPort: "9001",
-						Command:    "/bin/echo",
+						Name:        "svcOk2",
+						ListenPort:  "9001",
+						Command:     "/bin/echo",
+						KillCommand: stringPtr("/bin/echo"),
 						ResourceRequirements: map[string]int{
 							"VRAM-GPU-1": 3000,
 						},
@@ -254,4 +270,8 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/test-server/kill-command.json
+++ b/test-server/kill-command.json
@@ -1,0 +1,14 @@
+{
+  "ShutDownAfterInactivitySeconds": 3,
+  "Services": [
+    {
+      "Name": "test-server_idle-timeout",
+      "ListenPort": "2034",
+      "ProxyTargetHost": "localhost",
+      "ProxyTargetPort": "12034",
+      "Command": "test-server/test-server",
+      "Args": "-p 12034",
+      "KillCommand": "echo -n 'success' > /tmp/test-server-kill-command-output"
+    }
+  ]
+}


### PR DESCRIPTION
I run ComfyUI through Docker, which responds poorly (i.e. not at all) to the kill signal that LMP normally uses. To work around this, I've added support for optionally specifying custom kill commands, which will be executed before the primary termination mechanism.

This is semi-consistent with systemd's [`ExecStop`](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecStop=), which is what I was using prior to LMP. I chose to terminate the process regardless of the stop command, unlike systemd, to ensure that the rest of the invariants that LMP relies upon remain in place (i.e. the PID is dead-and-gone when the function exits).