### PR TITLE
JSON config tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 )
@@ -45,17 +46,20 @@ type ManagementApi struct {
 }
 
 func loadConfig(filePath string) (Config, error) {
-	var config Config
-
 	file, err := os.ReadFile(filePath)
 	if err != nil {
-		return config, err
+		return Config{}, err
 	}
+	return loadConfigFromReader(bytes.NewReader(file))
+}
 
-	decoder := json.NewDecoder(bytes.NewReader(file))
+func loadConfigFromReader(r io.Reader) (Config, error) {
+	var config Config
+
+	decoder := json.NewDecoder(r)
 	decoder.DisallowUnknownFields()
 
-	err = decoder.Decode(&config)
+	err := decoder.Decode(&config)
 	if err != nil {
 		return config, err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -5,275 +5,277 @@ import (
 	"testing"
 )
 
-func TestValidateConfig(t *testing.T) {
-	testCases := []struct {
-		name           string
-		cfg            Config
-		wantErr        bool
-		expectedErrMsg []string // substrings that should appear if wantErr==true
-	}{
-		{
-			name: "Valid config (minimal)",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000, "VRAM-GPU-1": 20000},
-				OpenAiApi: OpenAiApi{
-					ListenPort: "7070",
-				},
-				Services: []ServiceConfig{
-					{
-						Name:       "serviceA",
-						ListenPort: "8080",
-						Command:    "/bin/echo",
-					},
-					{
-						Name:       "serviceB",
-						ListenPort: "8081",
-						Command:    "/bin/echo",
-					},
-				},
-			},
-			wantErr: false,
+func checkExpectedErrorMessages(t *testing.T, err error, expectedMsgs []string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error but got nil")
+	}
+	errStr := err.Error()
+	for _, msg := range expectedMsgs {
+		if !strings.Contains(errStr, msg) {
+			t.Errorf("expected error to contain %q, but got:\n%s", msg, errStr)
+		}
+	}
+}
+
+func TestValidConfigMinimal(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000, "VRAM-GPU-1": 20000},
+		OpenAiApi: OpenAiApi{
+			ListenPort: "7070",
 		},
-		{
-			name: "Duplicate service names",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "serviceX",
-						ListenPort: "8090",
-						Command:    "/bin/echo",
-					},
-					{
-						Name:       "serviceX",
-						ListenPort: "8091",
-						Command:    "/bin/echo",
-					},
-				},
+		Services: []ServiceConfig{
+			{
+				Name:       "serviceA",
+				ListenPort: "8080",
+				Command:    "/bin/echo",
 			},
-			wantErr:        true,
-			expectedErrMsg: []string{"duplicate service name found", "serviceX"},
-		},
-		{
-			name: "Multiple services listening on same port",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "service1",
-						ListenPort: "8080",
-						Command:    "/bin/echo",
-					},
-					{
-						Name:       "service2",
-						ListenPort: "8080",
-						Command:    "/bin/echo",
-					},
-				},
+			{
+				Name:       "serviceB",
+				ListenPort: "8081",
+				Command:    "/bin/echo",
 			},
-			wantErr:        true,
-			expectedErrMsg: []string{"multiple services listening on port 8080", "service1", "service2"},
-		},
-		{
-			name: "Resource not in ResourcesAvailable",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "serviceNeedsGPU",
-						ListenPort: "8100",
-						Command:    "/bin/echo",
-						ResourceRequirements: map[string]int{
-							"VRAM-GPU-1": 100,
-						},
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"requires resource \"VRAM-GPU-1\" but it is not provided"},
-		},
-		{
-			name: "Healthcheck interval but no HealthcheckCommand",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:                            "serviceHC",
-						ListenPort:                      "8110",
-						Command:                         "/bin/echo",
-						HealthcheckIntervalMilliseconds: 200,
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"has HealthcheckIntervalMilliseconds set but no HealthcheckCommand"},
-		},
-		{
-			name: "OpenAiApi=false but no ListenPort",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:      "serviceOpenAI",
-						OpenAiApi: false,
-						Command:   "/bin/echo",
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"does not specify ListenPort", "serviceOpenAI"},
-		},
-		{
-			name: "Empty service name",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "",
-						ListenPort: "8200",
-						Command:    "/bin/echo",
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"has an empty Name"},
-		},
-		{
-			name: "Invalid port number (non-numeric)",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "badPortService",
-						ListenPort: "80abc",
-						Command:    "/bin/echo",
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"invalid ListenPort: \"80abc\"", "badPortService"},
-		},
-		{
-			name: "Invalid port number (out of range)",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "bigPortService",
-						ListenPort: "99999",
-						Command:    "/bin/echo",
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"invalid ListenPort: \"99999\"", "bigPortService"},
-		},
-		{
-			name: "No Command specified",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:       "noCommandService",
-						ListenPort: "8080",
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"has no Command specified", "noCommandService"},
-		},
-		{
-			name: "Standard KillCommand works",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				Services: []ServiceConfig{
-					{
-						Name:        "killCommandWorks",
-						ListenPort:  "8090",
-						Command:     "/bin/echo",
-						KillCommand: stringPtr("/bin/echo"),
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "All checks pass (bigger example)",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{
-					"RAM":        20000,
-					"VRAM-GPU-1": 10000,
-				},
-				OpenAiApi: OpenAiApi{
-					ListenPort: "6060",
-				},
-				ManagementApi: ManagementApi{
-					ListenPort: "7071",
-				},
-				Services: []ServiceConfig{
-					{
-						Name:       "svcOk",
-						ListenPort: "9000",
-						Command:    "/bin/echo",
-						ResourceRequirements: map[string]int{
-							"RAM": 2000,
-						},
-					},
-					{
-						Name:        "svcOk2",
-						ListenPort:  "9001",
-						Command:     "/bin/echo",
-						KillCommand: stringPtr("/bin/echo"),
-						ResourceRequirements: map[string]int{
-							"VRAM-GPU-1": 3000,
-						},
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Invalid ManagementApi port",
-			cfg: Config{
-				ResourcesAvailable: map[string]int{"RAM": 10000},
-				ManagementApi: ManagementApi{
-					ListenPort: "99999",
-				},
-				Services: []ServiceConfig{
-					{
-						Name:       "svcOk",
-						ListenPort: "9000",
-						Command:    "/bin/echo",
-					},
-				},
-			},
-			wantErr:        true,
-			expectedErrMsg: []string{"top-level ManagementApi.ListenPort is invalid: \"99999\""},
 		},
 	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			err := validateConfig(tc.cfg)
-
-			if tc.wantErr && err == nil {
-				t.Fatalf("expected error but got nil")
-			}
-			if !tc.wantErr && err != nil {
-				t.Fatalf("did not expect an error but got: %v", err)
-			}
-
-			if err != nil && tc.wantErr {
-				errStr := err.Error()
-				// Check that all expected substrings appear
-				for _, msg := range tc.expectedErrMsg {
-					if !strings.Contains(errStr, msg) {
-						t.Errorf("expected error to contain %q, but got:\n%s", msg, errStr)
-					}
-				}
-			}
-		})
+	err := validateConfig(cfg)
+	if err != nil {
+		t.Fatalf("did not expect an error but got: %v", err)
 	}
+}
+
+func TestDuplicateServiceNames(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "serviceX",
+				ListenPort: "8090",
+				Command:    "/bin/echo",
+			},
+			{
+				Name:       "serviceX",
+				ListenPort: "8091",
+				Command:    "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"duplicate service name found", "serviceX"})
+}
+
+func TestMultipleServicesSamePort(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "service1",
+				ListenPort: "8080",
+				Command:    "/bin/echo",
+			},
+			{
+				Name:       "service2",
+				ListenPort: "8080",
+				Command:    "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"multiple services listening on port 8080", "service1", "service2"})
+}
+
+func TestResourceNotInResourcesAvailable(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "serviceNeedsGPU",
+				ListenPort: "8100",
+				Command:    "/bin/echo",
+				ResourceRequirements: map[string]int{
+					"VRAM-GPU-1": 100,
+				},
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"requires resource \"VRAM-GPU-1\" but it is not provided"})
+}
+
+func TestHealthcheckIntervalNoCommand(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:                            "serviceHC",
+				ListenPort:                      "8110",
+				Command:                         "/bin/echo",
+				HealthcheckIntervalMilliseconds: 200,
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"has HealthcheckIntervalMilliseconds set but no HealthcheckCommand"})
+}
+
+func TestOpenAiApiNoListenPort(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:      "serviceOpenAI",
+				OpenAiApi: false,
+				Command:   "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"does not specify ListenPort", "serviceOpenAI"})
+}
+
+func TestEmptyServiceName(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "",
+				ListenPort: "8200",
+				Command:    "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"has an empty Name"})
+}
+
+func TestInvalidPortNumberNonNumeric(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "badPortService",
+				ListenPort: "80abc",
+				Command:    "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"invalid ListenPort: \"80abc\"", "badPortService"})
+}
+
+func TestInvalidPortNumberOutOfRange(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "bigPortService",
+				ListenPort: "99999",
+				Command:    "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"invalid ListenPort: \"99999\"", "bigPortService"})
+}
+
+func TestNoCommandSpecified(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:       "noCommandService",
+				ListenPort: "8080",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"has no Command specified", "noCommandService"})
+}
+
+func TestStandardKillCommandWorks(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		Services: []ServiceConfig{
+			{
+				Name:        "killCommandWorks",
+				ListenPort:  "8090",
+				Command:     "/bin/echo",
+				KillCommand: stringPtr("/bin/echo"),
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	if err != nil {
+		t.Fatalf("did not expect an error but got: %v", err)
+	}
+}
+
+func TestAllChecksPassBiggerExample(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{
+			"RAM":        20000,
+			"VRAM-GPU-1": 10000,
+		},
+		OpenAiApi: OpenAiApi{
+			ListenPort: "6060",
+		},
+		ManagementApi: ManagementApi{
+			ListenPort: "7071",
+		},
+		Services: []ServiceConfig{
+			{
+				Name:       "svcOk",
+				ListenPort: "9000",
+				Command:    "/bin/echo",
+				ResourceRequirements: map[string]int{
+					"RAM": 2000,
+				},
+			},
+			{
+				Name:        "svcOk2",
+				ListenPort:  "9001",
+				Command:     "/bin/echo",
+				KillCommand: stringPtr("/bin/echo"),
+				ResourceRequirements: map[string]int{
+					"VRAM-GPU-1": 3000,
+				},
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	if err != nil {
+		t.Fatalf("did not expect an error but got: %v", err)
+	}
+}
+
+func TestInvalidManagementApiPort(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		ResourcesAvailable: map[string]int{"RAM": 10000},
+		ManagementApi: ManagementApi{
+			ListenPort: "99999",
+		},
+		Services: []ServiceConfig{
+			{
+				Name:       "svcOk",
+				ListenPort: "9000",
+				Command:    "/bin/echo",
+			},
+		},
+	}
+	err := validateConfig(cfg)
+	checkExpectedErrorMessages(t, err, []string{"top-level ManagementApi.ListenPort is invalid: \"99999\""})
 }
 
 func stringPtr(s string) *string {

--- a/config_test.go
+++ b/config_test.go
@@ -294,3 +294,21 @@ func TestInvalidManagementApiPort(t *testing.T) {
 	}`)
 	checkExpectedErrorMessages(t, err, []string{"top-level ManagementApi.ListenPort is invalid: \"99999\""})
 }
+
+func TestNegativeShutDownAfterInactivitySeconds(t *testing.T) {
+	t.Parallel()
+	_, err := loadConfigFromString(t, `{
+		"ResourcesAvailable": {
+			"RAM": 10000
+		},
+		"ShutDownAfterInactivitySeconds": -10,
+		"Services": [
+			{
+				"Name": "testService",
+				"ListenPort": "8080",
+				"Command": "/bin/echo"
+			}
+		]
+	}`)
+	checkExpectedErrorMessages(t, err, []string{"cannot unmarshal number -10 into Go struct field Config.ShutDownAfterInactivitySeconds of type uint"})
+}


### PR DESCRIPTION
Pretty simple PR this time around - just does what we discussed with regards to using JSON for the config tests (which are now separate functions for clarity). Also readds the negative `ShutDownAfterInactivitySeconds` test.