### PR TITLE
bugfix: Fix that client connections were not immediately closed if a service never accepted a connection and exited

### DIFF
--- a/main.go
+++ b/main.go
@@ -753,17 +753,15 @@ func tryConnectingUntilTimeoutOrProcessExit(
 	}()
 
 	for time.Now().Before(deadline) {
-		if interrupted {
-			return nil, true
-		}
-
 		select {
 		case <-processExitedChannel:
 			log.Printf("[%s] Process terminated while trying to connect to %s:%s", serviceName, serviceHost, servicePort)
 			return nil, true
 		default:
 		}
-
+		if interrupted {
+			return nil, false
+		}
 		conn, err := net.DialTimeout("tcp", net.JoinHostPort(serviceHost, servicePort), 1*time.Second)
 		if err == nil {
 			return conn, false

--- a/main.go
+++ b/main.go
@@ -759,7 +759,7 @@ func tryConnectingUntilTimeoutOrProcessExit(
 
 		select {
 		case <-processExitedChannel:
-			log.Printf("[%s] Process exited while waiting to connect to %s:%s, aborting early", serviceName, serviceHost, servicePort)
+			log.Printf("[%s] Process terminated while trying to connect to %s:%s", serviceName, serviceHost, servicePort)
 			return nil, true
 		default:
 		}
@@ -771,7 +771,7 @@ func tryConnectingUntilTimeoutOrProcessExit(
 
 		select {
 		case <-processExitedChannel:
-			log.Printf("[%s] Process exited while trying to connect to %s:%s", serviceName, serviceHost, servicePort)
+			log.Printf("[%s] Process terminated while trying to connect to %s:%s", serviceName, serviceHost, servicePort)
 			return nil, true
 		case <-time.After(sleepDuration):
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -749,7 +749,7 @@ func testFailingToStartServiceIsCleaningUpResources(
 	defer func() {
 		_ = con.Close()
 	}()
-
+	assertRemoteClosedWithin(test, con, 2*time.Second)
 	time.Sleep(2 * time.Second) // Give lmp time to clean up
 	statusResponse = getStatusFromManagementAPI(test, managementApiAddress)
 	verifyServiceStatus(test, statusResponse, processName, false, map[string]int{resourceName: 0})

--- a/main_test.go
+++ b/main_test.go
@@ -750,7 +750,6 @@ func testFailingToStartServiceIsCleaningUpResources(
 		_ = con.Close()
 	}()
 	assertRemoteClosedWithin(test, con, 2*time.Second)
-	time.Sleep(2 * time.Second) // Give lmp time to clean up
 	statusResponse = getStatusFromManagementAPI(test, managementApiAddress)
 	verifyServiceStatus(test, statusResponse, processName, false, map[string]int{resourceName: 0})
 	verifyTotalResourceUsage(test, statusResponse, map[string]int{resourceName: 0})


### PR DESCRIPTION

fixes #86